### PR TITLE
Add Apache Beam executor

### DIFF
--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -152,6 +152,10 @@ def _get_executor(name: str) -> Executor:
         from rechunker.executors.dask import DaskExecutor
 
         return DaskExecutor()
+    elif name.lower() == "beam":
+        from rechunker.executors.beam import BeamExecutor
+
+        return BeamExecutor()
     elif name.lower() == "python":
         from rechunker.executors.python import PythonExecutor
 

--- a/rechunker/executors/beam.py
+++ b/rechunker/executors/beam.py
@@ -1,0 +1,91 @@
+from functools import partial
+import itertools
+import math
+import uuid
+from typing import Any, Iterable, Optional, Mapping, Tuple
+
+import apache_beam as beam
+
+from rechunker.types import CopySpec, StagedCopySpec, Executor
+
+
+class BeamExecutor(Executor[beam.PTransform]):
+    """An execution engine based on Apache Beam.
+
+    Supports copying between any arrays that implement ``__getitem__`` and
+    ``__setitem__`` for tuples of ``slice`` objects. Array must also be
+    serializable by Beam (i.e., with pickle).
+
+    Execution plans for BeamExecutor are beam.PTransform objects.
+    """
+
+    # TODO: explore adding an option to do rechunking with Beam groupby
+    # operations instead of explicitly writing intermediate arrays to disk.
+
+    def prepare_plan(self, specs: Iterable[StagedCopySpec]) -> beam.PTransform:
+        return "Rechunker" >> _Rechunker(specs)
+
+    def execute_plan(self, plan: beam.PTransform, **kwargs):
+        with beam.Pipeline(**kwargs) as pipeline:
+            pipeline | plan
+
+
+class _Rechunker(beam.PTransform):
+    def __init__(self, specs: Iterable[StagedCopySpec]):
+        super().__init__()
+        self.specs = tuple(specs)
+
+    def expand(self, pcoll):
+        max_depth = max(len(spec.stages) for spec in self.specs)
+        specs_map = {uuid.uuid1().hex: spec for spec in self.specs}
+
+        pcoll = pcoll | "Create" >> beam.Create([(k, None) for k in specs_map])
+        for stage in range(max_depth):
+            specs_by_target = {
+                k: v.stages[stage] if stage < len(v.stages) else None
+                for k, v in specs_map.items()
+            }
+            pcoll = pcoll | f"Stage{stage}" >> _Stage(specs_by_target)
+        return pcoll
+
+
+class _Stage(beam.PTransform):
+    def __init__(self, specs_by_target: Mapping[str, CopySpec]):
+        super().__init__()
+        self.specs_by_target = specs_by_target
+
+    def expand(self, pcoll):
+        start_fn = partial(_start_stage, self.specs_by_target)
+        return (
+            pcoll
+            | "Start" >> beam.FlatMapTuple(start_fn)
+            | "CreateTasks" >> beam.FlatMapTuple(_copy_tasks)
+            | "CopyChunks" >> beam.MapTuple(_copy_chunk)
+            | "Finish" >> beam.GroupByKey()
+        )
+
+
+def _start_stage(
+    specs_by_target_id: Mapping[str, Optional[CopySpec]],
+    target_id: str,
+    unused_value: Any,
+) -> Tuple[str, CopySpec]:
+    spec = specs_by_target_id[target_id]
+    if spec is not None:
+        yield target_id, spec
+
+
+def _copy_tasks(target_id: str, spec: CopySpec):
+    for key in _chunked_keys(spec.source.shape, spec.chunks):
+        yield target_id, key, spec.source, spec.target
+
+
+def _chunked_keys(shape: Tuple[int, ...], chunks: Tuple[int, ...]) -> Tuple[slice, ...]:
+    ranges = [range(math.ceil(s / c)) for s, c in zip(shape, chunks)]
+    for indices in itertools.product(*ranges):
+        yield tuple(slice(c * i, c * (i + 1)) for i, c in zip(indices, chunks))
+
+
+def _copy_chunk(target_id, key, source, target):
+    target[key] = source[key]
+    return (target_id, None)

--- a/rechunker/executors/beam.py
+++ b/rechunker/executors/beam.py
@@ -1,6 +1,5 @@
-from functools import partial
 import uuid
-from typing import Any, Iterable, Optional, Mapping, Tuple
+from typing import Iterable, Optional, Mapping, Tuple
 
 import apache_beam as beam
 

--- a/rechunker/executors/beam.py
+++ b/rechunker/executors/beam.py
@@ -25,6 +25,7 @@ class BeamExecutor(Executor[beam.PTransform]):
 
     # TODO: explore adding an option to do rechunking with Beam groupby
     # operations instead of explicitly writing intermediate arrays to disk.
+    # This would offer a cleaner API and would perhaps be faster, too.
 
     def prepare_plan(self, specs: Iterable[StagedCopySpec]) -> beam.PTransform:
         return "Rechunker" >> _Rechunker(specs)
@@ -45,6 +46,9 @@ class _Rechunker(beam.PTransform):
 
         # we explicitly thread target_id through each stage to ensure that they
         # are executed in order
+        # TODO: consider refactoring to use Beam's ``Source`` API for improved
+        # performance:
+        # https://beam.apache.org/documentation/io/developing-io-overview/
         pcoll = pcoll | "Create" >> beam.Create(specs_map.keys())
         for stage in range(max_depth):
             specs_by_target = {

--- a/rechunker/executors/beam.py
+++ b/rechunker/executors/beam.py
@@ -60,7 +60,9 @@ class _Stage(beam.PTransform):
             pcoll
             | "Start" >> beam.FlatMapTuple(start_fn)
             | "CreateTasks" >> beam.FlatMapTuple(_copy_tasks)
-            | "Reshuffle" >> beam.Reshuffle()  # prevent undesirable fusion
+            # prevent undesirable fusion
+            # https://stackoverflow.com/a/54131856/809705
+            | "Reshuffle" >> beam.Reshuffle()
             | "CopyChunks" >> beam.MapTuple(_copy_chunk)
             | "Finish" >> beam.GroupByKey()
         )

--- a/rechunker/executors/beam.py
+++ b/rechunker/executors/beam.py
@@ -60,6 +60,7 @@ class _Stage(beam.PTransform):
             pcoll
             | "Start" >> beam.FlatMapTuple(start_fn)
             | "CreateTasks" >> beam.FlatMapTuple(_copy_tasks)
+            | "Reshuffle" >> beam.Reshuffle()  # prevent undesirable fusion
             | "CopyChunks" >> beam.MapTuple(_copy_chunk)
             | "Finish" >> beam.GroupByKey()
         )

--- a/rechunker/executors/util.py
+++ b/rechunker/executors/util.py
@@ -1,0 +1,21 @@
+import itertools
+import math
+
+from typing import Iterator, Tuple
+
+
+def chunk_keys(
+    shape: Tuple[int, ...], chunks: Tuple[int, ...]
+) -> Iterator[Tuple[slice, ...]]:
+    """Iterator over array indexing keys of the desired chunk sized.
+
+    The union of all keys indexes every element of an array of shape ``shape``
+    exactly once. Each array resulting from indexing is of shape ``chunks``,
+    except possibly for the last arrays along each dimension (if ``chunks``
+    do not even divide ``shape``).
+    """
+    ranges = [range(math.ceil(s / c)) for s, c in zip(shape, chunks)]
+    for indices in itertools.product(*ranges):
+        yield tuple(
+            slice(c * i, min(c * (i + 1), s)) for i, s, c in zip(indices, shape, chunks)
+        )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ doc_requires = [
 ]
 
 extras_require = {
-    "complete": ["dask[array]", "zarr", "pyyaml", "fsspec"],
+    "complete": ["apache_beam", "dask[array]", "zarr", "pyyaml", "fsspec"],
     "docs": doc_requires,
 }
 extras_require["dev"] = extras_require["complete"] + [


### PR DESCRIPTION
This is a good example of an executor using a higher level execution graph than Dask.

I haven't actually tested this for performance on a real dataset yet, but I think it should be pretty reasonable.

Two potential improvements that could have a big impact on performance:

- [ ] Use Beam's `Source` API to make the job of schedulers easier: https://beam.apache.org/documentation/io/developing-io-python/
- [ ] Use `GroupByKey` for storing intermediate array data, instead of explicitly writing to intermediate arrays on disk. This would also be a bit easier for users -- no need to explicitly delete temporary arrays.