### PR TITLE
Refactor the data model for excutors

### DIFF
--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -7,7 +7,7 @@ import zarr
 import dask
 
 from rechunker.algorithm import rechunking_plan
-from rechunker.types import CopySpec, StagedCopySpec, Executor
+from rechunker.types import ArrayProxy, CopySpec, Executor
 
 
 class Rechunked:
@@ -218,10 +218,10 @@ def rechunk(
     """
     if isinstance(executor, str):
         executor = _get_executor(executor)
-    copy_specs, intermediate, target = _setup_rechunk(
+    copy_spec, intermediate, target = _setup_rechunk(
         source, target_chunks, max_mem, target_store, temp_store
     )
-    plan = executor.prepare_plan(copy_specs)
+    plan = executor.prepare_plan(copy_spec)
     return Rechunked(executor, plan, source, intermediate, target)
 
 
@@ -264,10 +264,8 @@ def _setup_rechunk(
             target_store,
             temp_store_or_group=temp_store,
         )
-        intermediate = (
-            copy_spec.stages[0].target if len(copy_spec.stages) == 2 else None
-        )
-        target = copy_spec.stages[-1].target
+        intermediate = copy_spec.intermediate.array
+        target = copy_spec.write.array
         return [copy_spec], intermediate, target
 
     else:
@@ -281,7 +279,7 @@ def _setup_array_rechunk(
     target_store_or_group,
     temp_store_or_group=None,
     name=None,
-) -> StagedCopySpec:
+) -> CopySpec:
     shape = source_array.shape
     source_chunks = (
         source_array.chunksize
@@ -334,16 +332,15 @@ def _setup_array_rechunk(
         pass
 
     if read_chunks == write_chunks:
-        return StagedCopySpec([CopySpec(source_array, target_array, read_chunks)])
+        int_array = None
     else:
         # do intermediate store
         assert temp_store_or_group is not None
         int_array = _zarr_empty(
             shape, temp_store_or_group, int_chunks, dtype, name=name
         )
-        return StagedCopySpec(
-            [
-                CopySpec(source_array, int_array, read_chunks),
-                CopySpec(int_array, target_array, write_chunks),
-            ]
-        )
+
+    read_proxy = ArrayProxy(source_array, read_chunks)
+    int_proxy = ArrayProxy(int_array, int_chunks)
+    write_proxy = ArrayProxy(target_array, write_chunks)
+    return CopySpec(read_proxy, int_proxy, write_proxy)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ doc_requires = [
 ]
 
 extras_require = {
-    "complete": ["apache_beam", "dask[array]", "zarr", "pyyaml", "fsspec"],
+    "complete": install_requires + ["apache_beam", "pyyaml", "fsspec"],
     "docs": doc_requires,
 }
 extras_require["dev"] = extras_require["complete"] + [


### PR DESCRIPTION
I originally thought that it made the most sense to think of rechunking as a chain of chunked array copies.

After going through the exercise of trying to write an Executor that doesn't use temporary arrays (https://github.com/pangeo-data/rechunker/pull/36), I realize now that this was overly generic. *Sometimes* it might make sense to implement a rechunking this way, but Rechunker's algorithm adds more structure than that. There is always a "push/pull" structure that splits read chunks into intermediate chunks, and then combines intermediate chunks into write chunks.

This structure wasn't evident from current data model and I needed it for my executor without temporaries, so this PR changes CopySpec to directly keep track of "read/intermediate/write" steps.

I've used this new representation in `api.py` and the dask executor. It's still convenient sometimes to use the "chain of copies" representation, so I've added the utility function `split_into_direct_copies()` for converting to this representation in `rechunker.executors.util`.