### PR TITLE
Pywren executor

### DIFF
--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -165,6 +165,10 @@ def _get_executor(name: str) -> Executor:
         from rechunker.executors.python import PythonExecutor
 
         return PythonExecutor()
+    elif name.lower() == "pywren":
+        from rechunker.executors.pywren import PywrenExecutor
+
+        return PywrenExecutor()
     else:
         raise ValueError(f"unrecognized executor {name}")
 

--- a/rechunker/executors/pywren.py
+++ b/rechunker/executors/pywren.py
@@ -1,0 +1,67 @@
+from functools import partial
+
+from typing import Callable, Iterable, Tuple
+
+from rechunker.executors.util import chunk_keys, split_into_direct_copies
+from rechunker.types import CopySpec, Executor, ReadableArray, WriteableArray
+
+import pywren_ibm_cloud as pywren
+from pywren_ibm_cloud.executor import FunctionExecutor
+
+# PywrenExecutor represents delayed execution tasks as functions that require
+# a FunctionExecutor.
+Task = Callable[[FunctionExecutor], None]
+
+
+class PywrenExecutor(Executor[Task]):
+    """An execution engine based on Pywren.
+
+    Supports zarr arrays as inputs. Outputs must be zarr arrays.
+
+    Any Pywren FunctionExecutor can be passed to the constructor. By default
+    a Pywren `local_executor` will be used
+
+    Execution plans for PywrenExecutor are functions that accept no arguments.
+    """
+
+    def __init__(self, pywren_function_executor: FunctionExecutor = None):
+        self.pywren_function_executor = pywren_function_executor
+
+    def prepare_plan(self, specs: Iterable[CopySpec]) -> Task:
+        tasks = []
+        for spec in specs:
+            for direct_spec in split_into_direct_copies(spec):
+                tasks.append(partial(_direct_array_copy, *direct_spec))
+        return partial(_execute_all, tasks)
+
+    def execute_plan(self, plan: Task):
+        if self.pywren_function_executor is None:
+            # No Pywren function executor specified, so use a local one, and shutdown after use
+            with pywren.local_executor() as pywren_function_executor:
+                plan(pywren_function_executor)
+        else:
+            plan(self.pywren_function_executor)
+
+
+def _direct_array_copy(
+    source: ReadableArray,
+    target: WriteableArray,
+    chunks: Tuple[int, ...],
+    pywren_function_executor: FunctionExecutor,
+) -> None:
+    """Direct copy between arrays using Pywren for parallelism"""
+    iterdata = [(source, target, key) for key in chunk_keys(source.shape, chunks)]
+
+    def direct_copy(iterdata):
+        source, target, key = iterdata
+        target[key] = source[key]
+
+    pywren_function_executor.map(direct_copy, iterdata)
+    pywren_function_executor.get_result()
+
+
+def _execute_all(
+    tasks: Iterable[Task], pywren_function_executor: FunctionExecutor
+) -> None:
+    for task in tasks:
+        task(pywren_function_executor)

--- a/rechunker/executors/pywren.py
+++ b/rechunker/executors/pywren.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 from functools import partial
 
 from typing import Callable, Iterable, Tuple
@@ -36,8 +35,8 @@ class PywrenExecutor(Executor[Task]):
             for direct_spec in split_into_direct_copies(spec):
                 spec_tasks.append(partial(_direct_array_copy, *direct_spec))
             tasks.append(partial(_execute_in_series, spec_tasks))
-        # Tasks for different specs can be executed in parallel
-        return partial(_execute_in_parallel, tasks)
+        # TODO: execute tasks for different specs in parallel
+        return partial(_execute_in_series, tasks)
 
     def execute_plan(self, plan: Task):
         if self.pywren_function_executor is None:
@@ -77,12 +76,3 @@ def _execute_in_series(
 ) -> None:
     for task in tasks:
         task(pywren_function_executor)
-
-
-def _execute_in_parallel(
-    tasks: Iterable[Task], pywren_function_executor: FunctionExecutor
-) -> None:
-    with concurrent.futures.ThreadPoolExecutor() as tpexecutor:
-        futures = [tpexecutor.submit(task, pywren_function_executor) for task in tasks]
-        for _ in concurrent.futures.as_completed(futures):
-            pass

--- a/rechunker/executors/pywren.py
+++ b/rechunker/executors/pywren.py
@@ -37,7 +37,10 @@ class PywrenExecutor(Executor[Task]):
     def execute_plan(self, plan: Task):
         if self.pywren_function_executor is None:
             # No Pywren function executor specified, so use a local one, and shutdown after use
-            with pywren.local_executor() as pywren_function_executor:
+            with pywren.local_executor(
+                # Minimal config needed to avoid Pywren error if ~/.pywren_config is missing
+                config={"pywren": {"storage_bucket": "unused"}}
+            ) as pywren_function_executor:
                 plan(pywren_function_executor)
         else:
             plan(self.pywren_function_executor)

--- a/rechunker/executors/pywren.py
+++ b/rechunker/executors/pywren.py
@@ -37,13 +37,17 @@ class PywrenExecutor(Executor[Task]):
     def execute_plan(self, plan: Task):
         if self.pywren_function_executor is None:
             # No Pywren function executor specified, so use a local one, and shutdown after use
-            with pywren.local_executor(
-                # Minimal config needed to avoid Pywren error if ~/.pywren_config is missing
-                config={"pywren": {"storage_bucket": "unused"}}
-            ) as pywren_function_executor:
+            with pywren_local_function_executor() as pywren_function_executor:
                 plan(pywren_function_executor)
         else:
             plan(self.pywren_function_executor)
+
+
+def pywren_local_function_executor():
+    return pywren.local_executor(
+        # Minimal config needed to avoid Pywren error if ~/.pywren_config is missing
+        config={"pywren": {"storage_bucket": "unused"}}
+    )
 
 
 def _direct_array_copy(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ doc_requires = [
 ]
 
 extras_require = {
-    "complete": install_requires + ["apache_beam", "pyyaml", "fsspec", "prefect"],
+    "complete": install_requires + ["apache_beam", "pyyaml", "fsspec", "prefect", "pywren_ibm_cloud"],
     "docs": doc_requires,
 }
 extras_require["dev"] = extras_require["complete"] + [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ doc_requires = [
 ]
 
 extras_require = {
-    "complete": install_requires + ["apache_beam", "pyyaml", "fsspec", "prefect", "pywren_ibm_cloud"],
+    "complete": install_requires
+    + ["apache_beam", "pyyaml", "fsspec", "prefect", "pywren_ibm_cloud"],
     "docs": doc_requires,
 }
 extras_require["dev"] = extras_require["complete"] + [

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -139,7 +139,14 @@ def test_rechunk_dask_array(
 
 
 @pytest.mark.parametrize(
-    "executor", ["dask", "python", requires_beam("beam"), requires_prefect("prefect")],
+    "executor",
+    [
+        "dask",
+        "python",
+        requires_beam("beam"),
+        requires_prefect("prefect"),
+        requires_pywren("pywren"),
+    ],
 )
 def test_rechunk_group(tmp_path, executor):
     store_source = str(tmp_path / "source.zarr")

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -26,6 +26,7 @@ def requires_import(module, *args):
 
 requires_beam = partial(requires_import, "apache_beam")
 requires_prefect = partial(requires_import, "prefect")
+requires_pywren = partial(requires_import, "pywren_ibm_cloud")
 
 
 @pytest.fixture(params=[(8000, 200), {"y": 8000, "x": 200}])
@@ -38,7 +39,7 @@ def target_chunks(request):
 @pytest.mark.parametrize("dtype", ["f4"])
 @pytest.mark.parametrize("max_mem", [25600000, "25.6MB"])
 @pytest.mark.parametrize(
-    "executor", ["dask", "python", requires_beam("beam"), requires_prefect("prefect")],
+    "executor", ["dask", "python", requires_beam("beam"), requires_prefect("prefect"), requires_pywren("pywren")],
 )
 @pytest.mark.parametrize(
     "dims,target_chunks",

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -39,7 +39,14 @@ def target_chunks(request):
 @pytest.mark.parametrize("dtype", ["f4"])
 @pytest.mark.parametrize("max_mem", [25600000, "25.6MB"])
 @pytest.mark.parametrize(
-    "executor", ["dask", "python", requires_beam("beam"), requires_prefect("prefect"), requires_pywren("pywren")],
+    "executor",
+    [
+        "dask",
+        "python",
+        requires_beam("beam"),
+        requires_prefect("prefect"),
+        requires_pywren("pywren"),
+    ],
 )
 @pytest.mark.parametrize(
     "dims,target_chunks",


### PR DESCRIPTION
Adds support for execution using https://github.com/pywren/pywren-ibm-cloud. (This is the actively maintained version of Pywren, which, despite the name, has support for a number of cloud backends.)

This is a serverless executor that fits well with rechunking Zarr arrays in cloud stores since there is no need to start and stop a cluster.

The recent refactoring in rechunker made this very easy to implement: it's basically the `PythonExecutor` with the `for` loop in `_direct_array_copy` replaced with Pywren's `map` function so the copies can be done in parallel.

The unit test uses Pywren's `local_executor` that uses local processes to run tasks. I have also manually tested the code using [Pywren's Google Cloud Run executor](https://github.com/pywren/pywren-ibm-cloud/commit/b97dec9c0d889f769be62384472b37dd58c7c444) (this is not yet in a released version of Pywren), although not at large scale. I should add some instructions on how to use this Pywren executor (and maybe others) at some point.

As a bit of background, I should mention that I also wrote a general Dask scheduler that uses Pywren [here](https://github.com/tomwhite/dask-executor-scheduler), and I've successfully got it to run rechunker using Cloud Run. The direct approach in this PR is simpler and probably preferable however.
