### PR TITLE
Add options for zarr array definition

### DIFF
--- a/rechunker/algorithm.py
+++ b/rechunker/algorithm.py
@@ -93,6 +93,8 @@ def rechunking_plan(
         Original chunk shape (must be in form (5, 10, 20), no irregular chunks)
     target_chunks : Tuple
         Target chunk shape (must be in form (5, 10, 20), no irregular chunks)
+    itemsize: int
+        Number of bytes used to represent a single array element
     max_mem : Int
         Maximum permissible chunk memory size, measured in units of itemsize
     consolidate_reads: bool, optional

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -311,7 +311,7 @@ def _setup_rechunk(
         raise ValueError("Source must be a Zarr Array or Group, or a Dask Array.")
 
 
-def _validation_options(options):
+def _validate_options(options):
     if not options:
         return
     for k in ["shape", "chunks", "dtype", "store", "name"]:
@@ -332,8 +332,8 @@ def _setup_array_rechunk(
     temp_options=None,
     name=None,
 ) -> CopySpec:
-    _validation_options(target_options)
-    _validation_options(temp_options)
+    _validate_options(target_options)
+    _validate_options(temp_options)
     shape = source_array.shape
     source_chunks = (
         source_array.chunksize

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -138,12 +138,6 @@ def _get_dims_from_zarr_array(z_array):
 
 
 def _zarr_empty(shape, store_or_group, chunks, dtype, name=None, **kwargs):
-    for k in ["shape", "chunks", "dtype", "store"]:
-        if k in kwargs:
-            raise ValueError(
-                f"Optional array arguments must not include {k} (provided {k}={kwargs[k]}). "
-                "Values for this property are managed internally."
-            )
     # wrapper that maybe creates the array within a group
     if name is not None:
         assert isinstance(store_or_group, zarr.hierarchy.Group)
@@ -317,6 +311,17 @@ def _setup_rechunk(
         raise ValueError("Source must be a Zarr Array or Group, or a Dask Array.")
 
 
+def _validation_options(options):
+    if not options:
+        return
+    for k in ["shape", "chunks", "dtype", "store", "name"]:
+        if k in options:
+            raise ValueError(
+                f"Optional array arguments must not include {k} (provided {k}={options[k]}). "
+                "Values for this property are managed internally."
+            )
+
+
 def _setup_array_rechunk(
     source_array,
     target_chunks,
@@ -327,6 +332,8 @@ def _setup_array_rechunk(
     temp_options=None,
     name=None,
 ) -> CopySpec:
+    _validation_options(target_options)
+    _validation_options(temp_options)
     shape = source_array.shape
     source_chunks = (
         source_array.chunksize

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -288,6 +288,18 @@ def test_rechunk_option_compression(rechunked_fn):
     assert size_compressed < size_uncompressed
 
 
+def test_rechunk_reserved_option(rechunked_fn):
+    for o in ["shape", "chunks", "dtype", "store", "name"]:
+        with pytest.raises(
+            ValueError, match=f"Optional array arguments must not include {o}"
+        ):
+            rechunked_fn(temp_options={o: True})
+        with pytest.raises(
+            ValueError, match=f"Optional array arguments must not include {o}"
+        ):
+            rechunked_fn(target_options={o: True})
+
+
 def test_repr_html(rechunked):
     rechunked._repr_html_()  # no exceptions
 


### PR DESCRIPTION
Fixes https://github.com/pangeo-data/rechunker/issues/46

This adds options to `rechunk` that are passed to zarr create methods.  The only use cases I have in mind for this are allowing for overwrites and compression, but it may be useful in other ways.  Otherwise it may eventually be worth lifting those parameters into the `rechunk` signature given that allowing any option to be passed is a bit of a footgun.

Note: I had to modify one of the existing test fixtures since it was doing almost what I wanted for a compression test except that the chunks were too small for compression to take effect.  I don't know that occurred with zarr but I can't find any other explanation for why specifying a compressor makes no difference when an array is too small.  I have no idea where the cutoff is but perhaps it is related to compression block sizes?  Let me know if anybody understands that better.

