### PR TITLE
Add pre-commit to build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,29 +20,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
+    - name: Run pre-commit
+      uses: pre-commit/action@v2.0.0
     - name: Test with pytest
       run: |
         py.test tests -v --cov=rechunker --cov-config .coveragerc --cov-report term-missing
         coverage xml
     - name: Codecov
       uses: codecov/codecov-action@v1
-
-  lint:
-
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 black
-    - name: Lint with flake8
-      run: |
-        flake8
-    - name: Check formatting
-      run: |
-        black --check . -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: 19.10b0
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     - id: flake8
-      language_version: python3.7
+      language_version: python3


### PR DESCRIPTION
https://github.com/pangeo-data/rechunker/issues/49

This would change the build to run the pre-commit hook before any tests.  

Do you guys (@TomAugspurger / @rabernat) have a preference on keeping the linting/formatting steps as a separate workflow?