### PR TITLE
check for nullness

### DIFF
--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -329,7 +329,7 @@ def _setup_rechunk(
         variables, attrs = encode_dataset_coordinates(source)
         attrs = _encode_zarr_attributes(attrs)
 
-        if temp_store:
+        if temp_store is not None:
             temp_group = zarr.group(temp_store)
         else:
             temp_group = None


### PR DESCRIPTION
This should fix #59. It was failing b/c a `fsspec.get_mapper()` evaluates to `False`. I don't know enough about `fsspec` but I guess that makes sense if a directory is not created yet. Regardless we should always check for nullness instead of `if var: do it` in those cases.