### PR TITLE
Allow target_chunks dict syntax for xarray inputs

### DIFF
--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -221,7 +221,7 @@ def rechunk(
     Parameters
     ----------
     source : zarr.Array, zarr.Group, dask.array.Array, or xarray.Dataset
-        Named dimensions in the Zarr Arrays will be parsed according to the
+        Named dimensions in the Zarr arrays will be parsed according to the
         Xarray :ref:`xarray:zarr_encoding`.
     target_chunks : tuple, dict, or None
         The desired chunks of the array after rechunking. The structure

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -148,9 +148,13 @@ def _zarr_empty(shape, store_or_group, chunks, dtype, name=None, **kwargs):
     # wrapper that maybe creates the array within a group
     if name is not None:
         assert isinstance(store_or_group, zarr.hierarchy.Group)
-        return store_or_group.empty(name, shape=shape, chunks=chunks, dtype=dtype, **kwargs)
+        return store_or_group.empty(
+            name, shape=shape, chunks=chunks, dtype=dtype, **kwargs
+        )
     else:
-        return zarr.empty(shape, chunks=chunks, dtype=dtype, store=store_or_group, **kwargs)
+        return zarr.empty(
+            shape, chunks=chunks, dtype=dtype, store=store_or_group, **kwargs
+        )
 
 
 ZARR_OPTIONS = [
@@ -212,12 +216,12 @@ def rechunk(
     executor: Union[str, Executor] = "dask",
 ) -> Rechunked:
     """
-    Rechunk a Zarr Array or Group, or a Dask Array
+    Rechunk a Zarr Array or Group, a Dask Array, or an Xarray Dataset
 
     Parameters
     ----------
-    source : zarr.Array, zarr.Group, or dask.array.Array
-        Named dimensions in the Arrays will be parsed according to the
+    source : zarr.Array, zarr.Group, dask.array.Array, or xarray.Dataset
+        Named dimensions in the Zarr Arrays will be parsed according to the
         Xarray :ref:`xarray:zarr_encoding`.
     target_chunks : tuple, dict, or None
         The desired chunks of the array after rechunking. The structure
@@ -285,7 +289,9 @@ def rechunk(
         from rechunker.executors.dask import DaskExecutor
 
         if not isinstance(executor, DaskExecutor):
-            raise NotImplementedError(f"Executor type {type(executor)} not supported for source {type(source)}.")
+            raise NotImplementedError(
+                f"Executor type {type(executor)} not supported for source {type(source)}."
+            )
 
     copy_spec, intermediate, target = _setup_rechunk(
         source=source,
@@ -316,7 +322,9 @@ def _setup_rechunk(
 
     if isinstance(source, xarray.Dataset):
         if not isinstance(target_chunks, dict):
-            raise ValueError("You must specify ``target-chunks`` as a dict when rechunking a dataset.")
+            raise ValueError(
+                "You must specify ``target-chunks`` as a dict when rechunking a dataset."
+            )
 
         variables, attrs = encode_dataset_coordinates(source)
         attrs = _encode_zarr_attributes(attrs)
@@ -340,14 +348,18 @@ def _setup_rechunk(
             # applicable for the `encoding` parameter in Dataset.to_zarr other than "chunks"
             options = target_options.get(name, {})
             if "chunks" in options:
-                raise ValueError(f"Chunks must be provided in ``target_chunks`` rather than options (variable={name})")
+                raise ValueError(
+                    f"Chunks must be provided in ``target_chunks`` rather than options (variable={name})"
+                )
             variable.encoding.update(options)
             variable = encode_zarr_variable(variable)
 
             # Extract the array encoding to get a default chunking, a step
             # which will also ensure that the target chunking is compatible
             # with the current chunking (only necessary for on-disk arrays)
-            variable_encoding = extract_zarr_variable_encoding(variable, raise_on_invalid=False, name=name)
+            variable_encoding = extract_zarr_variable_encoding(
+                variable, raise_on_invalid=False, name=name
+            )
             variable_chunks = target_chunks.get(name, variable_encoding["chunks"])
             if isinstance(variable_chunks, dict):
                 variable_chunks = _shape_dict_to_tuple(variable.dims, variable_chunks)
@@ -379,7 +391,9 @@ def _setup_rechunk(
 
     elif isinstance(source, zarr.hierarchy.Group):
         if not isinstance(target_chunks, dict):
-            raise ValueError("You must specify ``target-chunks`` as a dict when rechunking a group.")
+            raise ValueError(
+                "You must specify ``target-chunks`` as a dict when rechunking a group."
+            )
 
         if temp_store:
             temp_group = zarr.group(temp_store)
@@ -420,7 +434,9 @@ def _setup_rechunk(
         return [copy_spec], intermediate, target
 
     else:
-        raise ValueError(f"Source must be a Zarr Array, Zarr Group, Dask Array or Xarray Dataset (not {type(source)}).")
+        raise ValueError(
+            f"Source must be a Zarr Array, Zarr Group, Dask Array or Xarray Dataset (not {type(source)})."
+        )
 
 
 def _setup_array_rechunk(
@@ -436,7 +452,11 @@ def _setup_array_rechunk(
     _validate_options(target_options)
     _validate_options(temp_options)
     shape = source_array.shape
-    source_chunks = source_array.chunksize if isinstance(source_array, dask.array.Array) else source_array.chunks
+    source_chunks = (
+        source_array.chunksize
+        if isinstance(source_array, dask.array.Array)
+        else source_array.chunks
+    )
     dtype = source_array.dtype
     itemsize = dtype.itemsize
 
@@ -493,7 +513,9 @@ def _setup_array_rechunk(
         # do intermediate store
         if temp_store_or_group is None:
             raise ValueError(
-                "A temporary store location must be provided{}.".format(f" (array={name})" if name else "")
+                "A temporary store location must be provided{}.".format(
+                    f" (array={name})" if name else ""
+                )
             )
         int_array = _zarr_empty(
             shape,

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -148,13 +148,9 @@ def _zarr_empty(shape, store_or_group, chunks, dtype, name=None, **kwargs):
     # wrapper that maybe creates the array within a group
     if name is not None:
         assert isinstance(store_or_group, zarr.hierarchy.Group)
-        return store_or_group.empty(
-            name, shape=shape, chunks=chunks, dtype=dtype, **kwargs
-        )
+        return store_or_group.empty(name, shape=shape, chunks=chunks, dtype=dtype, **kwargs)
     else:
-        return zarr.empty(
-            shape, chunks=chunks, dtype=dtype, store=store_or_group, **kwargs
-        )
+        return zarr.empty(shape, chunks=chunks, dtype=dtype, store=store_or_group, **kwargs)
 
 
 ZARR_OPTIONS = [
@@ -289,9 +285,7 @@ def rechunk(
         from rechunker.executors.dask import DaskExecutor
 
         if not isinstance(executor, DaskExecutor):
-            raise NotImplementedError(
-                f"Executor type {type(executor)} not supported for source {type(source)}."
-            )
+            raise NotImplementedError(f"Executor type {type(executor)} not supported for source {type(source)}.")
 
     copy_spec, intermediate, target = _setup_rechunk(
         source=source,
@@ -322,9 +316,7 @@ def _setup_rechunk(
 
     if isinstance(source, xarray.Dataset):
         if not isinstance(target_chunks, dict):
-            raise ValueError(
-                "You must specify ``target-chunks`` as a dict when rechunking a dataset."
-            )
+            raise ValueError("You must specify ``target-chunks`` as a dict when rechunking a dataset.")
 
         variables, attrs = encode_dataset_coordinates(source)
         attrs = _encode_zarr_attributes(attrs)
@@ -348,18 +340,14 @@ def _setup_rechunk(
             # applicable for the `encoding` parameter in Dataset.to_zarr other than "chunks"
             options = target_options.get(name, {})
             if "chunks" in options:
-                raise ValueError(
-                    f"Chunks must be provided in ``target_chunks`` rather than options (variable={name})"
-                )
+                raise ValueError(f"Chunks must be provided in ``target_chunks`` rather than options (variable={name})")
             variable.encoding.update(options)
             variable = encode_zarr_variable(variable)
 
             # Extract the array encoding to get a default chunking, a step
             # which will also ensure that the target chunking is compatible
             # with the current chunking (only necessary for on-disk arrays)
-            variable_encoding = extract_zarr_variable_encoding(
-                variable, raise_on_invalid=False, name=name
-            )
+            variable_encoding = extract_zarr_variable_encoding(variable, raise_on_invalid=False, name=name)
             variable_chunks = target_chunks.get(name, variable_encoding["chunks"])
             if isinstance(variable_chunks, dict):
                 variable_chunks = _shape_dict_to_tuple(variable.dims, variable_chunks)
@@ -391,9 +379,7 @@ def _setup_rechunk(
 
     elif isinstance(source, zarr.hierarchy.Group):
         if not isinstance(target_chunks, dict):
-            raise ValueError(
-                "You must specify ``target-chunks`` as a dict when rechunking a group."
-            )
+            raise ValueError("You must specify ``target-chunks`` as a dict when rechunking a group.")
 
         if temp_store:
             temp_group = zarr.group(temp_store)
@@ -434,9 +420,7 @@ def _setup_rechunk(
         return [copy_spec], intermediate, target
 
     else:
-        raise ValueError(
-            f"Source must be a Zarr Array, Zarr Group, Dask Array or Xarray Dataset (not {type(source)})."
-        )
+        raise ValueError(f"Source must be a Zarr Array, Zarr Group, Dask Array or Xarray Dataset (not {type(source)}).")
 
 
 def _setup_array_rechunk(
@@ -452,11 +436,7 @@ def _setup_array_rechunk(
     _validate_options(target_options)
     _validate_options(temp_options)
     shape = source_array.shape
-    source_chunks = (
-        source_array.chunksize
-        if isinstance(source_array, dask.array.Array)
-        else source_array.chunks
-    )
+    source_chunks = source_array.chunksize if isinstance(source_array, dask.array.Array) else source_array.chunks
     dtype = source_array.dtype
     itemsize = dtype.itemsize
 
@@ -513,9 +493,7 @@ def _setup_array_rechunk(
         # do intermediate store
         if temp_store_or_group is None:
             raise ValueError(
-                "A temporary store location must be provided{}.".format(
-                    f" (array={name})" if name else ""
-                )
+                "A temporary store location must be provided{}.".format(f" (array={name})" if name else "")
             )
         int_array = _zarr_empty(
             shape,

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -361,6 +361,8 @@ def _setup_rechunk(
                 variable, raise_on_invalid=False, name=name
             )
             variable_chunks = target_chunks.get(name, variable_encoding["chunks"])
+            if isinstance(variable_chunks, dict):
+                variable_chunks = _shape_dict_to_tuple(variable.dims, variable_chunks)
 
             # Restrict options to only those that are specific to zarr and
             # not managed internally

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -74,7 +74,9 @@ def test_rechunk_dataset(
     a[-1] = numpy.nan
     ds = xarray.Dataset(
         dict(
-            a=xarray.DataArray(a, dims=["x", "y"], attrs={"a1": 1, "a2": [1, 2, 3], "a3": "x"}),
+            a=xarray.DataArray(
+                a, dims=["x", "y"], attrs={"a1": 1, "a2": [1, 2, 3], "a3": "x"}
+            ),
             b=xarray.DataArray(numpy.ones(shape[0]), dims=["x"]),
             c=xarray.DataArray(numpy.ones(shape[1]), dims=["y"]),
         ),
@@ -153,11 +155,15 @@ def test_rechunk_dataset(
         pytest.param(None, {"y": 8000, "x": 200}, marks=pytest.mark.xfail),
     ],
 )
-def test_rechunk_array(tmp_path, shape, source_chunks, dtype, dims, target_chunks, max_mem, executor):
+def test_rechunk_array(
+    tmp_path, shape, source_chunks, dtype, dims, target_chunks, max_mem, executor
+):
 
     ### Create source array ###
     store_source = str(tmp_path / "source.zarr")
-    source_array = zarr.ones(shape, chunks=source_chunks, dtype=dtype, store=store_source)
+    source_array = zarr.ones(
+        shape, chunks=source_chunks, dtype=dtype, store=store_source
+    )
     # add some attributes
     source_array.attrs["foo"] = "bar"
     if dims:
@@ -197,15 +203,11 @@ def test_rechunk_array(tmp_path, shape, source_chunks, dtype, dims, target_chunk
 @pytest.mark.parametrize("dtype", ["f4"])
 @pytest.mark.parametrize("max_mem", [25600000])
 @pytest.mark.parametrize(
-    "target_chunks",
-    [
-        (200, 8000),
-        (800, 8000),
-        (8000, 200),
-        (400, 8000),
-    ],
+    "target_chunks", [(200, 8000), (800, 8000), (8000, 200), (400, 8000),],
 )
-def test_rechunk_dask_array(tmp_path, shape, source_chunks, dtype, target_chunks, max_mem):
+def test_rechunk_dask_array(
+    tmp_path, shape, source_chunks, dtype, target_chunks, max_mem
+):
 
     ### Create source array ###
     source_array = dsa.ones(shape, chunks=source_chunks, dtype=dtype)
@@ -214,7 +216,9 @@ def test_rechunk_dask_array(tmp_path, shape, source_chunks, dtype, target_chunks
     target_store = str(tmp_path / "target.zarr")
     temp_store = str(tmp_path / "temp.zarr")
 
-    rechunked = api.rechunk(source_array, target_chunks, max_mem, target_store, temp_store=temp_store)
+    rechunked = api.rechunk(
+        source_array, target_chunks, max_mem, target_store, temp_store=temp_store
+    )
     assert isinstance(rechunked, api.Rechunked)
 
     target_array = zarr.open(target_store)
@@ -345,11 +349,7 @@ def rechunk_args(tmp_path, request):
         target_chunks = (8000, 200)
 
         args.update(
-            {
-                "source": array,
-                "target_chunks": target_chunks,
-                "max_mem": max_mem,
-            }
+            {"source": array, "target_chunks": target_chunks, "max_mem": max_mem,}
         )
     return args
 
@@ -414,13 +414,20 @@ def test_rechunk_no_temp_dir_provided_error(rechunk_args):
 
 def test_rechunk_option_compression(rechunk_args):
     def rechunk(compressor):
-        options = _wrap_options(rechunk_args["source"], dict(overwrite=True, compressor=compressor))
+        options = _wrap_options(
+            rechunk_args["source"], dict(overwrite=True, compressor=compressor)
+        )
         rechunked = api.rechunk(**rechunk_args, target_options=options)
         rechunked.execute()
-        return sum(file.stat().st_size for file in Path(rechunked._target.store.path).rglob("*"))
+        return sum(
+            file.stat().st_size
+            for file in Path(rechunked._target.store.path).rglob("*")
+        )
 
     size_uncompressed = rechunk(None)
-    size_compressed = rechunk(zarr.Blosc(cname="zstd", clevel=9, shuffle=zarr.Blosc.SHUFFLE))
+    size_compressed = rechunk(
+        zarr.Blosc(cname="zstd", clevel=9, shuffle=zarr.Blosc.SHUFFLE)
+    )
     assert size_compressed < size_uncompressed
 
 
@@ -448,7 +455,9 @@ def test_rechunk_bad_target_chunks(rechunk_args):
         return
     rechunk_args = dict(rechunk_args)
     rechunk_args["target_chunks"] = (10, 10)
-    with pytest.raises(ValueError, match="You must specify ``target-chunks`` as a dict"):
+    with pytest.raises(
+        ValueError, match="You must specify ``target-chunks`` as a dict"
+    ):
         api.rechunk(**rechunk_args)
 
 
@@ -457,7 +466,9 @@ def test_rechunk_invalid_source(tmp_path):
         ValueError,
         match="Source must be a Zarr Array, Zarr Group, Dask Array or Xarray Dataset",
     ):
-        api.rechunk([[1, 2], [3, 4]], target_chunks=(10, 10), max_mem=100, target_store=tmp_path)
+        api.rechunk(
+            [[1, 2], [3, 4]], target_chunks=(10, 10), max_mem=100, target_store=tmp_path
+        )
 
 
 @pytest.mark.parametrize(
@@ -478,8 +489,7 @@ def test_rechunk_invalid_source(tmp_path):
 )
 def test_unsupported_executor(tmp_path, source, target_chunks, executor):
     with pytest.raises(
-        NotImplementedError,
-        match="Executor type .* not supported for source",
+        NotImplementedError, match="Executor type .* not supported for source",
     ):
         api.rechunk(
             source,
@@ -516,7 +526,9 @@ def test_no_intermediate_fused(tmp_path):
     target_chunks = (400, 8000)
 
     store_source = str(tmp_path / "source.zarr")
-    source_array = zarr.ones(shape, chunks=source_chunks, dtype=dtype, store=store_source)
+    source_array = zarr.ones(
+        shape, chunks=source_chunks, dtype=dtype, store=store_source
+    )
 
     target_store = str(tmp_path / "target.zarr")
 
@@ -547,7 +559,9 @@ def test_pywren_function_executor(tmp_path):
 
         ### Create source array ###
         store_source = str(tmp_path / "source.zarr")
-        source_array = zarr.ones(shape, chunks=source_chunks, dtype=dtype, store=store_source)
+        source_array = zarr.ones(
+            shape, chunks=source_chunks, dtype=dtype, store=store_source
+        )
 
         ### Create targets ###
         target_store = str(tmp_path / "target.zarr")

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -74,9 +74,7 @@ def test_rechunk_dataset(
     a[-1] = numpy.nan
     ds = xarray.Dataset(
         dict(
-            a=xarray.DataArray(
-                a, dims=["x", "y"], attrs={"a1": 1, "a2": [1, 2, 3], "a3": "x"}
-            ),
+            a=xarray.DataArray(a, dims=["x", "y"], attrs={"a1": 1, "a2": [1, 2, 3], "a3": "x"}),
             b=xarray.DataArray(numpy.ones(shape[0]), dims=["x"]),
             c=xarray.DataArray(numpy.ones(shape[1]), dims=["y"]),
         ),
@@ -155,15 +153,11 @@ def test_rechunk_dataset(
         pytest.param(None, {"y": 8000, "x": 200}, marks=pytest.mark.xfail),
     ],
 )
-def test_rechunk_array(
-    tmp_path, shape, source_chunks, dtype, dims, target_chunks, max_mem, executor
-):
+def test_rechunk_array(tmp_path, shape, source_chunks, dtype, dims, target_chunks, max_mem, executor):
 
     ### Create source array ###
     store_source = str(tmp_path / "source.zarr")
-    source_array = zarr.ones(
-        shape, chunks=source_chunks, dtype=dtype, store=store_source
-    )
+    source_array = zarr.ones(shape, chunks=source_chunks, dtype=dtype, store=store_source)
     # add some attributes
     source_array.attrs["foo"] = "bar"
     if dims:
@@ -211,9 +205,7 @@ def test_rechunk_array(
         (400, 8000),
     ],
 )
-def test_rechunk_dask_array(
-    tmp_path, shape, source_chunks, dtype, target_chunks, max_mem
-):
+def test_rechunk_dask_array(tmp_path, shape, source_chunks, dtype, target_chunks, max_mem):
 
     ### Create source array ###
     source_array = dsa.ones(shape, chunks=source_chunks, dtype=dtype)
@@ -222,9 +214,7 @@ def test_rechunk_dask_array(
     target_store = str(tmp_path / "target.zarr")
     temp_store = str(tmp_path / "temp.zarr")
 
-    rechunked = api.rechunk(
-        source_array, target_chunks, max_mem, target_store, temp_store=temp_store
-    )
+    rechunked = api.rechunk(source_array, target_chunks, max_mem, target_store, temp_store=temp_store)
     assert isinstance(rechunked, api.Rechunked)
 
     target_array = zarr.open(target_store)
@@ -424,20 +414,13 @@ def test_rechunk_no_temp_dir_provided_error(rechunk_args):
 
 def test_rechunk_option_compression(rechunk_args):
     def rechunk(compressor):
-        options = _wrap_options(
-            rechunk_args["source"], dict(overwrite=True, compressor=compressor)
-        )
+        options = _wrap_options(rechunk_args["source"], dict(overwrite=True, compressor=compressor))
         rechunked = api.rechunk(**rechunk_args, target_options=options)
         rechunked.execute()
-        return sum(
-            file.stat().st_size
-            for file in Path(rechunked._target.store.path).rglob("*")
-        )
+        return sum(file.stat().st_size for file in Path(rechunked._target.store.path).rglob("*"))
 
     size_uncompressed = rechunk(None)
-    size_compressed = rechunk(
-        zarr.Blosc(cname="zstd", clevel=9, shuffle=zarr.Blosc.SHUFFLE)
-    )
+    size_compressed = rechunk(zarr.Blosc(cname="zstd", clevel=9, shuffle=zarr.Blosc.SHUFFLE))
     assert size_compressed < size_uncompressed
 
 
@@ -465,9 +448,7 @@ def test_rechunk_bad_target_chunks(rechunk_args):
         return
     rechunk_args = dict(rechunk_args)
     rechunk_args["target_chunks"] = (10, 10)
-    with pytest.raises(
-        ValueError, match="You must specify ``target-chunks`` as a dict"
-    ):
+    with pytest.raises(ValueError, match="You must specify ``target-chunks`` as a dict"):
         api.rechunk(**rechunk_args)
 
 
@@ -476,9 +457,7 @@ def test_rechunk_invalid_source(tmp_path):
         ValueError,
         match="Source must be a Zarr Array, Zarr Group, Dask Array or Xarray Dataset",
     ):
-        api.rechunk(
-            [[1, 2], [3, 4]], target_chunks=(10, 10), max_mem=100, target_store=tmp_path
-        )
+        api.rechunk([[1, 2], [3, 4]], target_chunks=(10, 10), max_mem=100, target_store=tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -537,9 +516,7 @@ def test_no_intermediate_fused(tmp_path):
     target_chunks = (400, 8000)
 
     store_source = str(tmp_path / "source.zarr")
-    source_array = zarr.ones(
-        shape, chunks=source_chunks, dtype=dtype, store=store_source
-    )
+    source_array = zarr.ones(shape, chunks=source_chunks, dtype=dtype, store=store_source)
 
     target_store = str(tmp_path / "target.zarr")
 
@@ -570,9 +547,7 @@ def test_pywren_function_executor(tmp_path):
 
         ### Create source array ###
         store_source = str(tmp_path / "source.zarr")
-        source_array = zarr.ones(
-            shape, chunks=source_chunks, dtype=dtype, store=store_source
-        )
+        source_array = zarr.ones(shape, chunks=source_chunks, dtype=dtype, store=store_source)
 
         ### Create targets ###
         target_store = str(tmp_path / "target.zarr")

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -45,7 +45,10 @@ def test_invalid_executor():
 
 @pytest.mark.parametrize("shape", [(100, 50)])
 @pytest.mark.parametrize("source_chunks", [(10, 50)])
-@pytest.mark.parametrize("target_chunks", [(20, 10)])
+@pytest.mark.parametrize(
+    "target_chunks",
+    [{"a": (20, 10), "b": (20,)}, {"a": {"x": 20, "y": 10}, "b": {"x": 20}}],
+)
 @pytest.mark.parametrize("max_mem", ["10MB"])
 @pytest.mark.parametrize("executor", ["dask"])
 @pytest.mark.parametrize("target_store", ["target.zarr", "mapper.target.zarr"])
@@ -94,7 +97,7 @@ def test_rechunk_dataset(
     )
     rechunked = api.rechunk(
         ds,
-        target_chunks=dict(a=target_chunks, b=target_chunks[:1]),
+        target_chunks=target_chunks,
         max_mem=max_mem,
         target_store=target_store,
         target_options=options,
@@ -112,8 +115,13 @@ def test_rechunk_dataset(
 
     # Validate decoded variables
     dst = xarray.open_zarr(target_store, decode_cf=True)
-    assert dst.a.data.chunksize == target_chunks
-    assert dst.b.data.chunksize == target_chunks[:1]
+    target_chunks_expected = (
+        target_chunks["a"]
+        if isinstance(target_chunks["a"], tuple)
+        else (target_chunks["a"]["x"], target_chunks["a"]["y"])
+    )
+    assert dst.a.data.chunksize == target_chunks_expected
+    assert dst.b.data.chunksize == target_chunks_expected[:1]
     assert dst.c.data.chunksize == source_chunks[1:]
     xarray.testing.assert_equal(ds.compute(), dst.compute())
     assert ds.attrs == dst.attrs
@@ -195,7 +203,13 @@ def test_rechunk_array(
 @pytest.mark.parametrize("dtype", ["f4"])
 @pytest.mark.parametrize("max_mem", [25600000])
 @pytest.mark.parametrize(
-    "target_chunks", [(200, 8000), (800, 8000), (8000, 200), (400, 8000),],
+    "target_chunks",
+    [
+        (200, 8000),
+        (800, 8000),
+        (8000, 200),
+        (400, 8000),
+    ],
 )
 def test_rechunk_dask_array(
     tmp_path, shape, source_chunks, dtype, target_chunks, max_mem
@@ -341,7 +355,11 @@ def rechunk_args(tmp_path, request):
         target_chunks = (8000, 200)
 
         args.update(
-            {"source": array, "target_chunks": target_chunks, "max_mem": max_mem,}
+            {
+                "source": array,
+                "target_chunks": target_chunks,
+                "max_mem": max_mem,
+            }
         )
     return args
 
@@ -481,7 +499,8 @@ def test_rechunk_invalid_source(tmp_path):
 )
 def test_unsupported_executor(tmp_path, source, target_chunks, executor):
     with pytest.raises(
-        NotImplementedError, match="Executor type .* not supported for source",
+        NotImplementedError,
+        match="Executor type .* not supported for source",
     ):
         api.rechunk(
             source,


### PR DESCRIPTION
Fixes the issue mentioned in #59. Xarray inputs should no longer require tuples and should be able to accept dicts as target_chunks.