### PR TITLE
Fix null temp

### DIFF
--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -395,7 +395,7 @@ def _setup_rechunk(
                 "You must specify ``target-chunks`` as a dict when rechunking a group."
             )
 
-        if temp_store:
+        if temp_store is not None:
             temp_group = zarr.group(temp_store)
         else:
             temp_group = None


### PR DESCRIPTION
## Overview
Similar to #59. I encountered the error when trying to rechunk from a zarr store to zarr store on the cloud using fsspec mapper. This PR works in the same exact way as PR #64, but with direct zarr store to zarr store rechunking rather than from dataset. It seems like current test doesn't capture this case.