### PR TITLE
Modify algorithm to try to reach chunk upper bound

### DIFF
--- a/rechunker/algorithm.py
+++ b/rechunker/algorithm.py
@@ -1,7 +1,10 @@
 """Core rechunking algorithm stuff."""
+import logging
 from typing import List, Optional, Sequence, Tuple
 
 from rechunker.compat import prod
+
+logger = logging.getLogger(__name__)
 
 
 def consolidate_chunks(
@@ -55,22 +58,35 @@ def consolidate_chunks(
     chunk_mem = itemsize * prod(chunks)
     if chunk_mem > max_mem:
         raise ValueError(f"chunk_mem {chunk_mem} > max_mem {max_mem}")
-    headroom = max_mem // chunk_mem
+    headroom = max_mem / chunk_mem
+    logger.debug(f"  initial headroom {headroom}")
 
     new_chunks = list(chunks)
     # only consolidate over these axes
     axes = sorted(chunk_limit_per_axis.keys())[::-1]
     for n_axis in axes:
-        c_new = min(
-            chunks[n_axis] * headroom, shape[n_axis], chunk_limit_per_axis[n_axis]
-        )
-        # print(f'  axis {n_axis}, {chunks[n_axis]} -> {c_new}')
-        new_chunks[n_axis] = c_new
+        upper_bound = min(shape[n_axis], chunk_limit_per_axis[n_axis])
+        # try to just increase the chunk to the upper bound
+        new_chunks[n_axis] = upper_bound
         chunk_mem = itemsize * prod(new_chunks)
-        headroom = max_mem // chunk_mem
+        upper_bound_headroom = max_mem / chunk_mem
+        if upper_bound_headroom > 1:
+            # ok it worked
+            headroom = upper_bound_headroom
+            logger.debug("  ! maxed out headroom")
+        else:
+            # nope, that was too much
+            # instead increase it by an integer multiple
+            larger_chunk = int(chunks[n_axis] * int(headroom))
+            # not sure the min check is needed any more; it safeguards against making it too big
+            new_chunks[n_axis] = min(larger_chunk, upper_bound)
+            chunk_mem = itemsize * prod(new_chunks)
+            headroom = max_mem / chunk_mem
 
-        if headroom == 1:
-            break
+        logger.debug(f"  axis {n_axis}, {chunks[n_axis]} -> {new_chunks[n_axis]}")
+        logger.debug(f"  chunk_mem {chunk_mem}, headroom {headroom}")
+
+        assert headroom >= 1
 
     return tuple(new_chunks)
 
@@ -126,6 +142,9 @@ def rechunking_plan(
         )
 
     if consolidate_writes:
+        logger.debug(
+            f"consolidate_write_chunks({shape}, {target_chunks}, {itemsize}, {max_mem})"
+        )
         write_chunks = consolidate_chunks(shape, target_chunks, itemsize, max_mem)
     else:
         write_chunks = tuple(target_chunks)
@@ -143,6 +162,9 @@ def rechunking_plan(
                 read_chunk_lim = None
             read_chunk_limits.append(read_chunk_lim)
 
+        logger.debug(
+            f"consolidate_read_chunks({shape}, {source_chunks}, {itemsize}, {max_mem}, {read_chunk_limits})"
+        )
         read_chunks = consolidate_chunks(
             shape, source_chunks, itemsize, max_mem, read_chunk_limits
         )

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -101,7 +101,7 @@ def _verify_plan_correctness(
     for n, sc, rc, ic, wc, tc in zip(
         shape, source_chunks, read_chunks, int_chunks, write_chunks, target_chunks
     ):
-        print(n, sc, rc, ic, wc, tc)
+        # print(n, sc, rc, ic, wc, tc)
         assert rc >= sc  # read chunks bigger or equal to source chunks
         assert wc >= tc  # write chunks bigger or equal to target chunks
         # write chunks are either as big as the whole dimension or else

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -86,6 +86,7 @@ def test_consolidate_chunks_4D(shape, chunks, itemsize, max_mem, expected):
 
 
 def _verify_plan_correctness(
+    shape,
     source_chunks,
     read_chunks,
     int_chunks,
@@ -97,13 +98,16 @@ def _verify_plan_correctness(
     assert itemsize * prod(read_chunks) <= max_mem
     assert itemsize * prod(int_chunks) <= max_mem
     assert itemsize * prod(write_chunks) <= max_mem
-    for sc, rc, ic, wc, tc in zip(
-        source_chunks, read_chunks, int_chunks, write_chunks, target_chunks
+    for n, sc, rc, ic, wc, tc in zip(
+        shape, source_chunks, read_chunks, int_chunks, write_chunks, target_chunks
     ):
-        assert rc >= sc
-        assert wc >= tc
-        assert ic == min(rc, wc)
-        # todo: check for write overlaps
+        print(n, sc, rc, ic, wc, tc)
+        assert rc >= sc  # read chunks bigger or equal to source chunks
+        assert wc >= tc  # write chunks bigger or equal to target chunks
+        # write chunks are either as big as the whole dimension or else
+        # evenly slice the target chunks (avoid conflicts)
+        assert (wc == n) or (wc % tc == 0)
+        assert ic == min(rc, wc)  # intermediate chunks smaller than rear or write
 
 
 @pytest.mark.parametrize(
@@ -117,7 +121,7 @@ def _verify_plan_correctness(
         ((8,), 4, (1,), (2,), 8, (2,), (2,), (2,)),
         ((8,), 4, (1,), (2,), 16, (4,), (4,), (4,)),  # consolidate
         ((8,), 4, (1,), (2,), 17, (4,), (4,), (4,)),  # no difference
-        ((16,), 4, (3,), (7,), 32, (6,), (6,), (7,)),  # uneven chunks
+        ((16,), 4, (3,), (7,), 32, (7,), (7,), (7,)),  # uneven chunks
     ],
 )
 def test_rechunking_plan_1D(
@@ -137,6 +141,7 @@ def test_rechunking_plan_1D(
     assert int_chunks == intermediate_chunks_expected
     assert write_chunks == write_chunks_expected
     _verify_plan_correctness(
+        shape,
         source_chunks,
         read_chunks,
         int_chunks,
@@ -176,6 +181,7 @@ def test_rechunking_plan_2d(
     assert int_chunks == intermediate_chunks_expected
     assert write_chunks == write_chunks_expected
     _verify_plan_correctness(
+        shape,
         source_chunks,
         read_chunks,
         int_chunks,
@@ -239,6 +245,7 @@ def test_rechunking_plan_hypothesis(inputs):
     assert len(write_chunks) == ndim
 
     _verify_plan_correctness(
+        shape,
         source_chunks,
         read_chunks,
         int_chunks,
@@ -247,3 +254,22 @@ def test_rechunking_plan_hypothesis(inputs):
         itemsize,
         max_mem,
     )
+
+
+# check for https://github.com/pangeo-data/rechunker/issues/115
+def test_intermediate_to_target_memory():
+    shape = (175320, 721, 1440)
+    source_chunks = (24, 721, 1440)
+    target_chunks = (21915, 103, 10)
+    itemsize = 4
+    max_mem = 12000000000  # 12 GB
+
+    read_chunks, int_chunks, write_chunks = rechunking_plan(
+        shape, source_chunks, target_chunks, itemsize, max_mem, consolidate_reads=True,
+    )
+
+    read_chunks2, int_chunks2, write_chunks2 = rechunking_plan(
+        shape, int_chunks, target_chunks, itemsize, max_mem, consolidate_reads=True,
+    )
+
+    assert read_chunks2 == int_chunks2 == write_chunks2


### PR DESCRIPTION
Fixes #115 

This modifies the algorithm in a very slight way. For each axis, it attempts to maximize the chunk size up to the full array shape or the specific chunk shape limit (for example, as determined by target_chunks). Previously it would just expand the chunks by an integer multiple of the original chunks.

I also added some additional tests to make sure we do not produce situations that would require write locking.