### PR TITLE
added write_empty_chunks to ZARR_OPTIONS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
 -   repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -166,6 +166,7 @@ ZARR_OPTIONS = [
     "cache_metadata",
     "cache_attrs",
     "overwrite",
+    "write_empty_chunks"
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 
-install_requires = ["dask[array,diagnostics]", "zarr", "xarray", "mypy_extensions"]
+install_requires = ["dask[array,diagnostics]", "zarr>=2.11", "xarray>2022.3", "mypy_extensions"]
 doc_requires = [
     "sphinx",
     "sphinxcontrib-srclinks",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,12 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 
-install_requires = ["dask[array,diagnostics]", "zarr>=2.11", "xarray>2022.3", "mypy_extensions"]
+install_requires = [
+    "dask[array,diagnostics]",
+    "zarr>=2.11",
+    "xarray>2022.3",
+    "mypy_extensions",
+]
 doc_requires = [
     "sphinx",
     "sphinxcontrib-srclinks",
@@ -26,7 +31,13 @@ extras_require = {
 extras_require["dev"] = (
     extras_require["complete"]
     + extras_require["test"]
-    + ["pytest-cov", "flake8", "black", "codecov", "mypy==0.782",]
+    + [
+        "pytest-cov",
+        "flake8",
+        "black",
+        "codecov",
+        "mypy==0.782",
+    ]
 )
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
 install_requires = [
     "dask[array,diagnostics]",
     "zarr>=2.11",
-    "xarray>2022.3",
+    "xarray>=2022.3",
     "mypy_extensions",
 ]
 doc_requires = [


### PR DESCRIPTION
Adds `write_empty_chunks` to ZARR_OPTIONS. This should allow the `write_empty_chunks` to be passed through to zarr. 

Similar functionality to this xarray PR: https://github.com/pydata/xarray/pull/6348

Closes #94 