### PR TITLE
Avoid unnecessary copy to intermediate store

### DIFF
--- a/rechunker/algorithm.py
+++ b/rechunker/algorithm.py
@@ -294,7 +294,7 @@ def multistage_rechunking_plan(
                 "achieving the minimum memory requirement due to increasing IO "
                 f"requirements. Smallest intermediates have size {int_mem}. "
                 f"Consider decreasing min_mem ({min_mem}) or increasing "
-                f"({max_mem}) to find a more efficient plan.",
+                f"max_mem ({max_mem}) to find a more efficient plan.",
                 category=ExcessiveIOWarning,
             )
             assert prev_plan is not None

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -609,7 +609,7 @@ def _setup_array_rechunk(
     except AttributeError:
         pass
 
-    if read_chunks == write_chunks:
+    if read_chunks == write_chunks or read_chunks == int_chunks:
         int_array = None
     else:
         # do intermediate store

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -790,8 +790,8 @@ def test_no_intermediate_fused(tmp_path):
     # rechunked.plan is a list of dask delayed objects
     num_tasks = len([v for v in rechunked.plan[0].dask.values() if dask.core.istask(v)])
     assert num_tasks < 20  # less than if no fuse
-    
-    
+
+
 def test_no_intermediate_store(tmp_path):
     """Test behaviour when read_chunks == int_chunks."""
     shape = (1000, 2000, 2000)
@@ -806,9 +806,10 @@ def test_no_intermediate_store(tmp_path):
     )
 
     target_store = str(tmp_path / "target.zarr")
-    temp_store= str(tmp_path / "temp_store.zarr")
-    rechunked = api.rechunk(source_array, target_chunks, max_mem, target_store,
-                            temp_store=temp_store)
+    temp_store = str(tmp_path / "temp_store.zarr")
+    rechunked = api.rechunk(
+        source_array, target_chunks, max_mem, target_store, temp_store=temp_store
+    )
     assert "Intermediate" not in repr(rechunked)
 
 

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -790,6 +790,26 @@ def test_no_intermediate_fused(tmp_path):
     # rechunked.plan is a list of dask delayed objects
     num_tasks = len([v for v in rechunked.plan[0].dask.values() if dask.core.istask(v)])
     assert num_tasks < 20  # less than if no fuse
+    
+    
+def test_no_intermediate_store(tmp_path):
+    """Test behaviour when read_chunks == int_chunks."""
+    shape = (1000, 2000, 2000)
+    source_chunks = (1, 2000, 2000)
+    dtype = "f4"
+    max_mem = 20000000000
+    target_chunks = (1000, 4, 4)
+
+    store_source = str(tmp_path / "source.zarr")
+    source_array = zarr.ones(
+        shape, chunks=source_chunks, dtype=dtype, store=store_source
+    )
+
+    target_store = str(tmp_path / "target.zarr")
+    temp_store= str(tmp_path / "temp_store.zarr")
+    rechunked = api.rechunk(source_array, target_chunks, max_mem, target_store,
+                            temp_store=temp_store)
+    assert "Intermediate" not in repr(rechunked)
 
 
 def test_rechunk_array_to_group_no_name(tmp_path):


### PR DESCRIPTION
Hi @rabernat !

I guess I find a case where `rechunker` unnecessary create copies to the intermediate store.
It's a small fix but it avoid wasting computations when the rechunking can be done without intermediate copies to disk.  

Here below a reproducible example of when he could occur: 

```
import numpy as np
import dask.utils 
from rechunker.algorithm import rechunking_plan

dtype = np.dtypes.Float32DType()
itemsize = dtype.itemsize

shape = (1000, 2000, 2000)
source_chunks = (1, 2000, 2000) 
target_chunks = (1000, 4, 4)


max_mem = dask.utils.parse_bytes("20 GB")


read_chunks, int_chunks, write_chunks = rechunking_plan(
    shape=shape,
    source_chunks=source_chunks,
    target_chunks=target_chunks,
    itemsize=itemsize,
    max_mem=max_mem,
    consolidate_reads=False,
)

print(read_chunks)
print(int_chunks)
print(write_chunks)

```

