### PR TITLE
Remove wildcard rm from tutorial

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -200,7 +200,6 @@
     }
    ],
    "source": [
-    "! rm -rf *.zarr # clean up any existing temporary data\n",
     "ds.to_zarr(\"air_temperature.zarr\")"
    ]
   },


### PR DESCRIPTION
The Toy tutorial guides the user to execute `rm -rf *.zarr`, which I find a little bit dangerous for the user.

Someone carefully following the tutorial is likely to be inexperienced user, possibly without much experience with Linux. If such a user runs the tutorial in the same directory as they store zarr data they might end up deleting all their data.

As by that point the tutorial does not produce any data, running `rm -rf *.zarr` seems like an excessive precaution. Therefore, I would like to suggest removing this command from tutorial.

If you don't agree with my reasoning - feel free to close this PR.