### PR TITLE
Fix for dask 2024.12 and xarray 2024.10, update CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,13 +1,17 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Unreleased
 ----------
+- Fix for to dask>=2014.12.0. By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 v0.5.1 - 2023-03-14
 -------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,7 +3,9 @@ Release Notes
 
 Unreleased
 ----------
-- Fix for to dask>=2014.12.0. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+- Fix for dask>=2024.12.0. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+- Fix for xarray>=2024.10.0 with datasets opened directly from disk. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 
 v0.5.1 - 2023-03-14
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = [
 dependencies = [
   "dask[array,diagnostics]",
   "mypy_extensions",
-  "zarr>=2.11",
+  "zarr<3,>=2.11",
 ]
 [project.optional-dependencies]
 complete = [
@@ -37,7 +37,7 @@ dev = [
   "flake8",
   "hypothesis",
   "IPython",
-  "mypy==0.782",
+  "mypy",
   "nbsphinx",
   "numpydoc",
   "pytest",

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -436,7 +436,7 @@ def _setup_rechunk(
             options = target_options.get(name, {})
             if "chunks" in options:
                 raise ValueError(
-                    f"Chunks must be provided in ``target_chunks`` rather than options (variable={name})"
+                    f"Chunks must be provided in 'target_chunks' rather than options (variable={name})"
                 )
             variable.encoding.update(options)
             variable = encode_zarr_variable(variable)

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -438,6 +438,8 @@ def _setup_rechunk(
                 raise ValueError(
                     f"Chunks must be provided in 'target_chunks' rather than options (variable={name})"
                 )
+            # Drop any leftover chunks encoding
+            variable.encoding.pop("chunks", None)
             variable.encoding.update(options)
             variable = encode_zarr_variable(variable)
 

--- a/rechunker/executors/dask.py
+++ b/rechunker/executors/dask.py
@@ -5,7 +5,6 @@ from packaging.version import Version
 import dask
 from dask.blockwise import BlockwiseDepDict, blockwise
 from dask.delayed import Delayed
-from dask._task_spec import TaskRef as _TaskRef
 from dask.highlevelgraph import HighLevelGraph
 
 from rechunker.types import ParallelPipelines, Pipeline, PipelineExecutor
@@ -13,7 +12,8 @@ from rechunker.types import ParallelPipelines, Pipeline, PipelineExecutor
 
 # Change in how dask collection token are given to blockwise()
 if Version(dask.__version__) >= Version('2024.12.0'):
-    TaskRef = _TaskRef
+    # TaskRef introduced in dask 2024.9
+    from dask._task_spec import TaskRef
 else:
     TaskRef = lambda x: x
 

--- a/rechunker/executors/dask.py
+++ b/rechunker/executors/dask.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Set, Tuple, Union
-from packaging.version import Version
+
 import dask
 from dask.blockwise import BlockwiseDepDict, blockwise
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
+from packaging.version import Version
 
 from rechunker.types import ParallelPipelines, Pipeline, PipelineExecutor
 
-
 # Change in how dask collection token are given to blockwise()
-if Version(dask.__version__) >= Version('2024.12.0'):
+if Version(dask.__version__) >= Version("2024.12.0"):
     # TaskRef introduced in dask 2024.9
     from dask._task_spec import TaskRef
 else:

--- a/rechunker/executors/dask.py
+++ b/rechunker/executors/dask.py
@@ -11,8 +11,11 @@ from packaging.version import Version
 from rechunker.types import ParallelPipelines, Pipeline, PipelineExecutor
 
 # Change in how dask collection token are given to blockwise()
-if Version(dask.__version__) >= Version("2024.12.0"):
-    # TaskRef introduced in dask 2024.9
+if Version(dask.__version__) >= Version("2025.1.0"):
+    # Public module exposed in 2025.1
+    from dask.task_spec import TaskRef
+elif Version(dask.__version__) >= Version("2024.12.0"):
+    # TaskRef introduced in dask 2024.9, but only necessary in block wise as of 2024.12
     from dask._task_spec import TaskRef
 else:
     TaskRef = lambda x: x

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -232,6 +232,8 @@ def test_rechunk_dataset(
     xarray = pytest.importorskip("xarray")
 
     ds = example_dataset(shape).chunk(chunks=dict(zip(["x", "y"], source_chunks)))
+    # Emulate a dataset opened from a zarr on disk
+    ds['a'].encoding['chunks'] = source_chunks
     options = dict(
         a=dict(
             compressor=zarr.Blosc(cname="zstd"),
@@ -240,6 +242,7 @@ def test_rechunk_dataset(
             _FillValue=-9999,
         )
     )
+
     rechunked = api.rechunk(
         ds,
         target_chunks=target_chunks,

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -233,7 +233,7 @@ def test_rechunk_dataset(
 
     ds = example_dataset(shape).chunk(chunks=dict(zip(["x", "y"], source_chunks)))
     # Emulate a dataset opened from a zarr on disk
-    ds['a'].encoding['chunks'] = source_chunks
+    ds["a"].encoding["chunks"] = source_chunks
     options = dict(
         a=dict(
             compressor=zarr.Blosc(cname="zstd"),

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -721,7 +721,7 @@ def test_rechunk_invalid_option(rechunk_args):
         options = _wrap_options(rechunk_args["source"], {"chunks": 10})
         with pytest.raises(
             ValueError,
-            match="Chunks must be provided in ``target_chunks`` rather than options",
+            match="Chunks must be provided in 'target_chunks' rather than options",
         ):
             api.rechunk(**rechunk_args, target_options=options)
     else:

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -259,13 +259,13 @@ def test_rechunk_dataset(
         thing_to_open = target_store
 
     # Validate encoded variables
-    dst = xarray.open_zarr(thing_to_open, decode_cf=False)
+    dst = xarray.open_zarr(thing_to_open, decode_cf=False, consolidated=False)
     assert dst.a.dtype == options["a"]["dtype"]
     assert all(dst.a.values[-1] == options["a"]["_FillValue"])
     assert dst.a.encoding["compressor"] is not None
 
     # Validate decoded variables
-    dst = xarray.open_zarr(thing_to_open, decode_cf=True)
+    dst = xarray.open_zarr(thing_to_open, decode_cf=True, consolidated=False)
     target_chunks_expected = (
         target_chunks["a"]
         if isinstance(target_chunks["a"], tuple)
@@ -325,7 +325,7 @@ def test_rechunk_dataset_dimchunks(
         rechunked.execute()
 
     # Validate decoded variables
-    dst = xarray.open_zarr(target_store, decode_cf=True)
+    dst = xarray.open_zarr(target_store, decode_cf=True, consolidated=False)
     target_chunks_expected = [
         target_chunks.get("x", source_chunks[0]),
         target_chunks.get("y", source_chunks[1]),


### PR DESCRIPTION
This fixes #155, allowing `rechunker` to be used with dask >= 2024.12.0.

The change in dask's `blockwise` was introduced in https://github.com/dask/dask/pull/11568 and requires keys pointing to other dask collections to be wrapped within `TaskRef` objects. The latter were introduced in dask 2024.09, so to preserve retro-compatibility ( `rechunker` doesn't pin  `dask`), I added a if-else that checks dask's version.

I tested against dask 2024.9, 2024.11.2, 2024.12 and 2025.2.

Installing `apache-beam` requires `dask < 2024.8.0` because the former needs `cloudpickle < 2.3` and the latter `>=3`, thus I didn't test if my change had impacts on the  `apache-beam` tests. (I guess it shouldn't...)

EDIT : I added a commit that fixes #154. 

EDIT : I also enabled the CI for the latest python versions and pinned zarr <3. I haven't looked inside the bug with the latest zarr, but it does bug.