### PR TITLE
Fix for xarray 2025.03.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Can't test on 3.13 yet because apache_beam does not support it
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   all-dependencies:
@@ -28,12 +32,16 @@ jobs:
 
   min-dependencies:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v0.5.4 - 2025-04-02
+v0.5.4 - 2025-05-01
 -------------------
 - Fix for xarray>=2025.03.1.  By `Pascal Bourgault <https://github.com/aulemahal>`_.
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v0.5.4 - 2025-04-02
+-------------------
+- Fix for xarray>=2025.03.1.  By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 v0.5.3 - 2025-03-20
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 complete = [
   # Min pin to avoid a compilation error with apache_beam when pip tries 2.27
-  "apache_beam>=2.45",
+  "apache_beam>=2.28",
   "fsspec",
   "prefect<2",
   "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
 ]
 [project.optional-dependencies]
 complete = [
-  "apache_beam",
+  # Min pin to avoid a compilation error with apache_beam when pip tries 2.27
+  "apache_beam>=2.45",
   "fsspec",
   "prefect<2",
   "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dynamic = [
 dependencies = [
   "dask[array,diagnostics]",
   "mypy_extensions",
+  "packaging",
   "zarr<3,>=2.11",
 ]
 [project.optional-dependencies]

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -7,6 +7,7 @@ from typing import Union
 import dask
 import dask.array
 import zarr
+from packaging.version import Version
 
 from rechunker.algorithm import rechunking_plan
 from rechunker.pipeline import CopySpecToPipelinesMixin
@@ -446,8 +447,11 @@ def _setup_rechunk(
             # Extract the array encoding to get a default chunking, a step
             # which will also ensure that the target chunking is compatible
             # with the current chunking (only necessary for on-disk arrays)
+            kws = {}
+            if Version(xarray.__version__) >= Version("2025.03.1"):
+                kws = {"zarr_format": 2}
             variable_encoding = extract_zarr_variable_encoding(
-                variable, raise_on_invalid=False, name=name
+                variable, raise_on_invalid=False, name=name, **kws
             )
             variable_chunks = target_chunks.get(name, variable_encoding["chunks"])
             if isinstance(variable_chunks, dict):


### PR DESCRIPTION
The latest xarray added a new argument  `zarr_format` to the private `xr.backends.zarr.extract_zarr_variable_encoding` function. This PR adds an if-else to give this argument for the appropriate xarray versions.

I would like to push a new patch release when this PR is merged.