### PR TITLE
zarr version 3 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # Can't test on 3.13 yet because apache_beam does not support it
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "dask[array,diagnostics]",
   "mypy_extensions",
   "packaging",
-  "zarr<3,>=2.11",
+  "zarr>=3.0.8,<4.0",
 ]
 [project.optional-dependencies]
 complete = [
@@ -31,7 +31,7 @@ complete = [
   "fsspec",
   "prefect<2",
   "pyyaml",
-  "xarray>=2022.3",
+  "xarray>=2024.3.0",
 ]
 dev = [
   "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "dask[array,diagnostics]",
   "mypy_extensions",
   "packaging",
-  "zarr>=3.0.8,<4.0",
+  "zarr<4.0,>=3.0.8",
 ]
 [project.optional-dependencies]
 complete = [
@@ -31,7 +31,7 @@ complete = [
   "fsspec",
   "prefect<2",
   "pyyaml",
-  "xarray>=2024.3.0",
+  "xarray>=2024.3",
 ]
 dev = [
   "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {file = "LICENSE"}
 authors = [
     {name = "Pangeo developers", email = "ryan.abernathey@gmail.com"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dynamic = [
   "version",
 ]

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -688,9 +688,9 @@ def _setup_array_rechunk(
                 source_array.metadata, "dimension_names"
             ):
                 if source_array.metadata.dimension_names:
-                    temp_zarr_options["dimension_names"] = (
-                        source_array.metadata.dimension_names
-                    )
+                    temp_zarr_options[
+                        "dimension_names"
+                    ] = source_array.metadata.dimension_names
 
         int_array = _zarr_empty(
             shape,

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -1,4 +1,5 @@
 """User-facing functions."""
+
 import html
 import textwrap
 from collections import defaultdict
@@ -132,13 +133,28 @@ def _shape_dict_to_tuple(dims, shape_dict):
 def _get_dims_from_zarr_array(z_array):
     # use Xarray convention
     # http://xarray.pydata.org/en/stable/internals.html#zarr-encoding-specification
-    return z_array.attrs["_ARRAY_DIMENSIONS"]
+
+    if (
+        hasattr(z_array, "metadata")
+        and hasattr(z_array.metadata, "dimension_names")
+        and z_array.metadata.dimension_names
+    ):
+        return z_array.metadata.dimension_names
+
+    # Fall back to xarray convention
+    if "_ARRAY_DIMENSIONS" in z_array.attrs:
+        return z_array.attrs["_ARRAY_DIMENSIONS"]
+
+    raise KeyError(
+        "Could not read dimension names from metadata or attributes of Zarr array."
+    )
 
 
 def _encode_zarr_attributes(attrs):
     from xarray.backends.zarr import encode_zarr_attr_value
 
-    return {k: encode_zarr_attr_value(v) for k, v in attrs.items()}
+    filtered_attrs = _filter_attributes(attrs)
+    return {k: encode_zarr_attr_value(v) for k, v in filtered_attrs.items()}
 
 
 def _zarr_empty(shape, store_or_group, chunks, dtype, name=None, **kwargs):
@@ -146,7 +162,7 @@ def _zarr_empty(shape, store_or_group, chunks, dtype, name=None, **kwargs):
     if isinstance(store_or_group, zarr.Group):
         assert name is not None
         return store_or_group.empty(
-            name, shape=shape, chunks=chunks, dtype=dtype, **kwargs
+            name=name, shape=shape, chunks=chunks, dtype=dtype, **kwargs
         )
     else:
         # ignore name
@@ -156,7 +172,7 @@ def _zarr_empty(shape, store_or_group, chunks, dtype, name=None, **kwargs):
 
 
 ZARR_OPTIONS = [
-    "compressor",
+    "codecs",
     "filters",
     "order",
     "cache_metadata",
@@ -355,12 +371,19 @@ def parse_target_chunks_from_dim_chunks(ds, target_chunks):
 def _copy_group_attributes(source, target):
     """Visit every source group and create it on the target and move any attributes found."""
 
-    def _update_group_attrs(name):
-        if isinstance(source.get(name), zarr.Group):
-            group = target.create_group(name)
-            group.attrs.update(source.get(name).attrs)
+    def _update_group_attrs_recursive(src_group, tgt_group, path=""):
+        # Process all items in the current group
+        for name in src_group.keys():
+            full_path = f"{path}/{name}" if path else name
+            item = src_group[name]
+            if isinstance(item, zarr.Group):
+                # Create the subgroup in target and copy attributes
+                sub_target = tgt_group.create_group(name)
+                sub_target.attrs.update(item.attrs)
+                # Recursively process subgroups
+                _update_group_attrs_recursive(item, sub_target, full_path)
 
-    source.visit(_update_group_attrs)
+    _update_group_attrs_recursive(source, target)
 
 
 def _setup_rechunk(
@@ -476,13 +499,15 @@ def _setup_rechunk(
                 temp_store_or_group=temp_group,
                 temp_options=options,
                 name=name,
+                dimension_names=variable.dims,
             )
-            copy_spec.write.array.attrs.update(variable_attrs)  # type: ignore
+
+            copy_spec.write.array.attrs.update(_filter_attributes(variable_attrs))
             copy_specs.append(copy_spec)
 
         return copy_specs, temp_group, target_group
 
-    elif isinstance(source, zarr.hierarchy.Group):
+    elif isinstance(source, zarr.Group):
         if not isinstance(target_chunks, dict):
             raise ValueError(
                 "You must specify ``target-chunks`` as a dict when rechunking a group."
@@ -521,7 +546,7 @@ def _setup_rechunk(
 
         return copy_specs, temp_group, target_group
 
-    elif isinstance(source, (zarr.core.Array, dask.array.Array)):
+    elif isinstance(source, (zarr.Array, dask.array.Array)):
         if (
             isinstance(target_store, zarr.Group) or isinstance(temp_store, zarr.Group)
         ) and array_name is None:
@@ -547,6 +572,22 @@ def _setup_rechunk(
         )
 
 
+def _filter_attributes(attrs):
+    """
+    Remove any attributes that are NaN. These cause errors when
+    written to the Zarr stores
+    """
+    import numpy as np
+
+    filtered_attrs = {}
+    for k, v in attrs.items():
+        if isinstance(v, (float, np.floating)) and np.isnan(v):
+            continue
+        filtered_attrs[k] = v
+
+    return filtered_attrs
+
+
 def _setup_array_rechunk(
     source_array,
     target_chunks,
@@ -556,6 +597,7 @@ def _setup_array_rechunk(
     temp_store_or_group=None,
     temp_options=None,
     name=None,
+    dimension_names=None,
 ) -> CopySpec:
     _validate_options(target_options)
     _validate_options(temp_options)
@@ -586,7 +628,7 @@ def _setup_array_rechunk(
     max_mem = dask.utils.parse_bytes(max_mem)
 
     # don't consolidate reads for Dask arrays
-    consolidate_reads = isinstance(source_array, zarr.core.Array)
+    consolidate_reads = isinstance(source_array, zarr.Array)
     read_chunks, int_chunks, write_chunks = rechunking_plan(
         shape,
         source_chunks,
@@ -602,16 +644,27 @@ def _setup_array_rechunk(
     int_chunks = tuple(int(x) for x in int_chunks)
     write_chunks = tuple(int(x) for x in write_chunks)
 
+    zarr_options = target_options or {}
+    if dimension_names is not None:
+        zarr_options["dimension_names"] = dimension_names
+    elif isinstance(source_array, zarr.Array):
+        # If source is a zarr array with dimension_names, preserve them
+        if hasattr(source_array, "metadata") and hasattr(
+            source_array.metadata, "dimension_names"
+        ):
+            if source_array.metadata.dimension_names:
+                zarr_options["dimension_names"] = source_array.metadata.dimension_names
+
     target_array = _zarr_empty(
         shape,
         target_store_or_group,
         target_chunks,
         dtype,
         name=name,
-        **(target_options or {}),
+        **zarr_options,
     )
     try:
-        target_array.attrs.update(source_array.attrs)
+        target_array.attrs.update(_filter_attributes(source_array.attrs))
     except AttributeError:
         pass
 
@@ -625,13 +678,27 @@ def _setup_array_rechunk(
                     f" (array={name})" if name else ""
                 )
             )
+        # Add dimension_names to temp options if provided
+        temp_zarr_options = temp_options or {}
+        if dimension_names is not None:
+            temp_zarr_options["dimension_names"] = dimension_names
+        elif isinstance(source_array, zarr.Array):
+            # If source is a zarr array with dimension_names, preserve them
+            if hasattr(source_array, "metadata") and hasattr(
+                source_array.metadata, "dimension_names"
+            ):
+                if source_array.metadata.dimension_names:
+                    temp_zarr_options["dimension_names"] = (
+                        source_array.metadata.dimension_names
+                    )
+
         int_array = _zarr_empty(
             shape,
             temp_store_or_group,
             int_chunks,
             dtype,
             name=name,
-            **(temp_options or {}),
+            **temp_zarr_options,
         )
 
     read_proxy = ArrayProxy(source_array, read_chunks)

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -9,7 +9,9 @@ import numpy
 import numpy as np
 import pytest
 import zarr
-from zarr.storage import FSStore
+from zarr.storage import LocalStore
+from zarr.codecs import BloscCodec, BytesCodec
+from zarr.codecs.blosc import BloscShuffle
 
 from rechunker import api
 
@@ -190,10 +192,10 @@ def test_get_dim_chunk(dask_chunks, chunk_ds, dim, target_chunks, expected):
 def target_store(tmp_path, request):
     if request.param == "mapper":
         pytest.importorskip("fsspec")
-        return FSStore(str(tmp_path) + "target.zarr")
+        return LocalStore(str(tmp_path) + "target.zarr")
     elif request.param == "group":
         pytest.importorskip("fsspec")
-        store = FSStore(str(tmp_path) + "group.target.zarr")
+        store = LocalStore(str(tmp_path) + "group.target.zarr")
         return zarr.group(store)
     else:
         return str(tmp_path / "mapper.target.zarr")
@@ -203,10 +205,10 @@ def target_store(tmp_path, request):
 def temp_store(tmp_path, request):
     if request.param == "mapper":
         pytest.importorskip("fsspec")
-        return FSStore(str(tmp_path) + "temp.zarr")
+        return LocalStore(str(tmp_path) + "temp.zarr")
     elif request.param == "group":
         pytest.importorskip("fsspec")
-        store = FSStore(str(tmp_path) + "group.temp.zarr")
+        store = LocalStore(str(tmp_path) + "group.temp.zarr")
         return zarr.group(store)
     else:
         return str(tmp_path / "mapper.temp.zarr")
@@ -236,7 +238,7 @@ def test_rechunk_dataset(
     ds["a"].encoding["chunks"] = source_chunks
     options = dict(
         a=dict(
-            compressor=zarr.Blosc(cname="zstd"),
+            codecs=[BytesCodec(), BloscCodec(cname="zstd")],
             dtype="int32",
             scale_factor=0.1,
             _FillValue=-9999,
@@ -265,7 +267,7 @@ def test_rechunk_dataset(
     dst = xarray.open_zarr(thing_to_open, decode_cf=False, consolidated=False)
     assert dst.a.dtype == options["a"]["dtype"]
     assert all(dst.a.values[-1] == options["a"]["_FillValue"])
-    assert dst.a.encoding["compressor"] is not None
+    assert dst.a.encoding.get("compressors") is not None
 
     # Validate decoded variables
     dst = xarray.open_zarr(thing_to_open, decode_cf=True, consolidated=False)
@@ -309,7 +311,7 @@ def test_rechunk_dataset_dimchunks(
     ds = example_dataset(shape).chunk(chunks=dict(zip(["x", "y"], source_chunks)))
     options = dict(
         a=dict(
-            compressor=zarr.Blosc(cname="zstd"),
+            codecs=[BytesCodec(), BloscCodec(cname="zstd")],
             dtype="int32",
             scale_factor=0.1,
             _FillValue=-9999,
@@ -496,7 +498,7 @@ def test_rechunk_dask_array(
 def test_rechunk_group(tmp_path, executor, source_store, target_store, temp_store):
     if source_store.startswith("mapper"):
         pytest.importorskip("fsspec")
-        store_source = FSStore(str(tmp_path) + source_store)
+        store_source = LocalStore(str(tmp_path) + source_store)
     else:
         store_source = str(tmp_path / source_store)
 
@@ -504,9 +506,9 @@ def test_rechunk_group(tmp_path, executor, source_store, target_store, temp_stor
     group.create_group("foo/bar/baz")
 
     # 800 byte chunks
-    a = group.ones("a", shape=(5, 10, 20), chunks=(1, 10, 20), dtype="f4")
+    a = group.ones(name="a", shape=(5, 10, 20), chunks=(1, 10, 20), dtype="f4")
     a.attrs["description"] = "a array description"
-    b = group["foo/bar/baz"].ones("b", shape=(20,), chunks=(10,), dtype="f4")
+    b = group["foo/bar/baz"].ones(name="b", shape=(20,), chunks=(10,), dtype="f4")
     b.attrs["description"] = "b array description"
 
     # group attributes
@@ -580,9 +582,9 @@ def sample_zarr_group(tmp_path):
     group = zarr.group(path)
     group.attrs["foo"] = "bar"
     # 800 byte chunks
-    a = group.ones("a", shape=(10, 20, 40), chunks=(5, 10, 4), dtype="f4")
+    a = group.ones(name="a", shape=(10, 20, 40), chunks=(5, 10, 4), dtype="f4")
     a.attrs["foo"] = "bar"
-    b = group.ones("b", shape=(8000,), chunks=(200,), dtype="f4")
+    b = group.ones(name="b", shape=(8000,), chunks=(200,), dtype="f4")
     b.attrs["foo"] = "bar"
     return group
 
@@ -658,9 +660,9 @@ def _is_collection(source):
 
     assert isinstance(
         source,
-        (dask.array.Array, zarr.core.Array, zarr.hierarchy.Group, xarray.Dataset),
+        (dask.array.Array, zarr.Array, zarr.Group, xarray.Dataset),
     )
-    return isinstance(source, (zarr.hierarchy.Group, xarray.Dataset))
+    return isinstance(source, (zarr.Group, xarray.Dataset))
 
 
 def _wrap_options(source, options):
@@ -673,7 +675,12 @@ def test_rechunk_option_overwrite(rechunk_args):
     api.rechunk(**rechunk_args).execute()
     # TODO: make this match more reliable based on outcome of
     # https://github.com/zarr-developers/zarr-python/issues/605
-    with pytest.raises(ValueError, match=r"path .* contains an array"):
+    from zarr.errors import ContainsArrayError
+
+    with pytest.raises(
+        (ValueError, ContainsArrayError),
+        match=r"(path .* contains an array|An array exists)",
+    ):
         api.rechunk(**rechunk_args).execute()
     options = _wrap_options(rechunk_args["source"], dict(overwrite=True))
     api.rechunk(**rechunk_args, target_options=options).execute()
@@ -697,20 +704,26 @@ def test_rechunk_no_temp_dir_provided_error(rechunk_args):
 
 
 def test_rechunk_option_compression(rechunk_args):
-    def rechunk(compressor):
+    def rechunk(codecs):
         options = _wrap_options(
-            rechunk_args["source"], dict(overwrite=True, compressor=compressor)
+            rechunk_args["source"], dict(overwrite=True, codecs=codecs)
         )
         rechunked = api.rechunk(**rechunk_args, target_options=options)
         rechunked.execute()
-        return sum(
-            file.stat().st_size
-            for file in Path(rechunked._target.store.path).rglob("*")
-        )
 
-    size_uncompressed = rechunk(None)
+        store = rechunked._target.store
+        if hasattr(store, "root"):
+            store_path = store.root
+        elif hasattr(store, "path"):
+            store_path = store.path
+        else:
+            store_path = str(store)
+
+        return sum(file.stat().st_size for file in Path(store_path).rglob("*"))
+
+    size_uncompressed = rechunk([BytesCodec()])
     size_compressed = rechunk(
-        zarr.Blosc(cname="zstd", clevel=9, shuffle=zarr.Blosc.SHUFFLE)
+        [BytesCodec(), BloscCodec(cname="zstd", clevel=9, shuffle=BloscShuffle.shuffle)]
     )
     assert size_compressed < size_uncompressed
 

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -9,9 +9,9 @@ import numpy
 import numpy as np
 import pytest
 import zarr
-from zarr.storage import LocalStore
 from zarr.codecs import BloscCodec, BytesCodec
 from zarr.codecs.blosc import BloscShuffle
+from zarr.storage import LocalStore
 
 from rechunker import api
 


### PR DESCRIPTION
We have a workload that makes heavy use of rechunker. As we've migrated to use Zarr version 3, Rechunker is something we've hoped to see move in this direction too. We attempted a dask-only solution using examples from a few blog posts, but it was painfully slow, so I decided to dive in to Rechunker and give it a go.

Disclaimer: I'm not an expert in either Zarr or Rechunker, but I figure I'd share this as a starting point if someone more knowledgeable wanted to do it "right". I've got this working well for my use case, but it's possible others will see corners I've missed (or just blatant errors). I've got all the basic tests passing, but I've never messed with prefect or beam. 

A couple things I'm not sure about: 
1. zarr v3 doesn't seem to handle NaNs in attributes. Right now, I'm just filtering them out, but maybe there is a better solution someone has
2. I don't think this is at all backward compatible, and I'm not sure if that's something this group wants to see. From what I see, I don't think it would be *awful* to have it support both library versions, but my use case didn't have the need and so I stopped short of trying to do that. 

Re: #159 